### PR TITLE
Model selfcontainment and model file for python 3.7

### DIFF
--- a/Keras-openface-convertion.ipynb
+++ b/Keras-openface-convertion.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
@@ -43,10 +41,18 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /home/kwiscion/anaconda3/lib/python3.7/site-packages/tensorflow/python/framework/op_def_library.py:263: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "Colocations handled automatically by placer.\n"
+     ]
+    }
+   ],
    "source": [
     "myInput = Input(shape=(96, 96, 3))\n",
     "\n",
@@ -283,9 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Load weights from csv files (which was exported from Openface torch model)\n",
@@ -302,21 +306,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 4,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "model.save('./model/nn4.small2.lrn.h5')"
+    "model.save('./model/nn4.small2.lrn.python.3.7.h5')"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "!open ."
@@ -324,47 +324,32 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "source": [
     "## Generate the embeddings "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/victor_sy_wang/anaconda/lib/python2.7/site-packages/keras/models.py:245: UserWarning: No training configuration found in save file: the model was *not* compiled. Compile it manually.\n",
-      "  warnings.warn('No training configuration found in save file: '\n"
-     ]
-    },
-    {
-     "ename": "NameError",
-     "evalue": "name 'cv2' is not defined",
+     "ename": "SyntaxError",
+     "evalue": "Missing parentheses in call to 'print'. Did you mean print(img.shape)? (<ipython-input-5-d3502a0262a6>, line 12)",
      "output_type": "error",
      "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-d93c051831bc>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;31m# Read a sample image as input to test the model\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 9\u001b[0;31m \u001b[0mimg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcv2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mimread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'./data/dlib-affine-sz/Aaron_Eckhart/Aaron_Eckhart_0001.png'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     10\u001b[0m \u001b[0mimg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mimg\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[0mimg\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0maround\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtranspose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimg\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0;36m255.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecimals\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m12\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'cv2' is not defined"
+      "\u001b[0;36m  File \u001b[0;32m\"<ipython-input-5-d3502a0262a6>\"\u001b[0;36m, line \u001b[0;32m12\u001b[0m\n\u001b[0;31m    print img.shape\u001b[0m\n\u001b[0m            ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m Missing parentheses in call to 'print'. Did you mean print(img.shape)?\n"
      ]
     }
    ],
    "source": [
     "from keras.models import load_model\n",
-    "# model = load_model('./model/nn4.small2.lrn.h5')\n",
-    "from keras.utils import CustomObjectScope\n",
-    "import tensorflow as tf\n",
-    "with CustomObjectScope({'tf': tf}):\n",
-    "    model = load_model('./model/nn4.small2.lrn.h5')\n",
+    "model = load_model('./model/nn4.small2.lrn.python.3.7.h5')\n",
+    "# from keras.utils import CustomObjectScope\n",
+    "# import tensorflow as tf\n",
+    "# with CustomObjectScope({'tf': tf}):\n",
+    "#     model = load_model('./model/nn4.small2.lrn.h5')\n",
     "\n",
     "# Read a sample image as input to test the model\n",
     "img = cv2.imread('./data/dlib-affine-sz/Aaron_Eckhart/Aaron_Eckhart_0001.png', 1)\n",
@@ -386,9 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -596,21 +579,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/utils.py
+++ b/utils.py
@@ -30,6 +30,7 @@ def concatenate(tensors, axis=-1):
   return tf.concat(axis, tensors)
 
 def LRN2D(x):
+  import tensorflow as tf
   return tf.nn.lrn(x, alpha=1e-4, beta=0.75)
 
 def conv2d_bn(


### PR DESCRIPTION
1. Added `import tensorflow as tf` within LRN2D to make loading available without `CustomObjectScope`
2. Built the model under python 3.7 (Models with `Lambda` layers are not protable between pythons `3.x`) - saved as 'model/nn4.small2.lrn.python.3.7.h5'